### PR TITLE
Remove .unacceptablelanguageignore

### DIFF
--- a/.github/workflows/soundness.yaml
+++ b/.github/workflows/soundness.yaml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   unacceptable-language-check:
     name: Unacceptable language check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
       - name: Checkout repository
@@ -17,7 +17,7 @@ jobs:
 
   license-header-check:
     name: License headers check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
       - name: Checkout repository
@@ -27,7 +27,7 @@ jobs:
 
   format-check:
     name: Format check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   unit-test:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,1 +1,0 @@
-scripts/check-unacceptable-language.sh

--- a/scripts/check-unacceptable-language.sh
+++ b/scripts/check-unacceptable-language.sh
@@ -31,16 +31,11 @@ error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
 UNACCEPTABLE_WORD_LIST="blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging"
+CURRENT_SCRIPT_PATH="$(realpath "$0")"
 
-unacceptable_language_lines=
-if [[ -f .unacceptablelanguageignore ]]; then
-    log "Found for unacceptable file..."
-    log "Checking for unacceptable language..."
-    unacceptable_language_lines=$(tr '\n' '\0' < .unacceptablelanguageignore | xargs -0 -I% printf '":(exclude)%" '| xargs git grep -i -I -w -H -n --column -E "${UNACCEPTABLE_WORD_LIST// /|}" | grep -v "ignore-unacceptable-language") || true | /usr/bin/paste -s -d " " -
-else
-    log "Checking for unacceptable language..."
-    unacceptable_language_lines=$(git grep -i -I -w -H -n --column -E "${UNACCEPTABLE_WORD_LIST// /|}" | grep -v "ignore-unacceptable-language") || true | /usr/bin/paste -s -d " " -
-fi
+log "Checking for unacceptable language..."
+
+unacceptable_language_lines=$(git grep -i -I -w -H -n --column -E "${UNACCEPTABLE_WORD_LIST// /|}" ":(exclude)$CURRENT_SCRIPT_PATH" | grep -v "ignore-unacceptable-language") || true | /usr/bin/paste -s -d " " -
 
 if [ -n "${unacceptable_language_lines}" ]; then
     fatal " ❌ Found unacceptable language:


### PR DESCRIPTION
`.unacceptablelanguageignore` was only used to ignore the check script itself, but I now inlined this ignore pattern instead.
