### PR TITLE
Add tracing hook in OpenFeatureTracing module

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -33,6 +33,7 @@ jobs:
           llvm-cov export -format "lcov" \
             .build/debug/swift-open-featurePackageTests.xctest \
             -ignore-filename-regex="\/Tests\/" \
+            -ignore-filename-regex="\/OpenFeatureTestSupport\/" \
             -ignore-filename-regex="\/.build\/" \
             -instr-profile=./.build/debug/codecov/default.profdata \
           > info.lcov

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.2.0"),
     ],
     targets: [
         .target(
@@ -22,8 +23,31 @@ let package = Package(
             name: "OpenFeatureTests",
             dependencies: [
                 .target(name: "OpenFeature"),
+                .target(name: "OpenFeatureTestSupport"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+            ]
+        ),
+
+        .target(
+            name: "OpenFeatureTracing",
+            dependencies: [
+                .target(name: "OpenFeature"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
+            ]
+        ),
+        .testTarget(
+            name: "OpenFeatureTracingTests",
+            dependencies: [
+                .target(name: "OpenFeatureTracing"),
+                .target(name: "OpenFeatureTestSupport"),
+            ]
+        ),
+
+        .target(
+            name: "OpenFeatureTestSupport",
+            dependencies: [
+                .target(name: "OpenFeature")
             ]
         ),
     ],

--- a/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
@@ -100,8 +100,8 @@ package struct AnyOpenFeatureEvaluation {
     }
 }
 
-private extension OpenFeatureEvaluation {
-    func eraseToAnyEvaluation() -> AnyOpenFeatureEvaluation {
+extension OpenFeatureEvaluation {
+    fileprivate func eraseToAnyEvaluation() -> AnyOpenFeatureEvaluation {
         AnyOpenFeatureEvaluation(self)
     }
 }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
@@ -13,43 +13,55 @@
 
 import OpenFeature
 
-struct OpenFeatureClosureHook: OpenFeatureHook {
-    typealias BeforeEvaluation = @Sendable (
+package struct OpenFeatureClosureHook: OpenFeatureHook {
+    package typealias BeforeEvaluation = @Sendable (
         _ context: inout OpenFeatureHookContext,
         _ hints: OpenFeatureHookHints
     ) throws -> Void
 
-    typealias AfterSuccessfulEvaluation = @Sendable (
+    package typealias AfterSuccessfulEvaluation = @Sendable (
         _ context: OpenFeatureHookContext,
         _ evaluation: AnyOpenFeatureEvaluation,
         _ hints: OpenFeatureHookHints
     ) throws -> Void
 
-    typealias OnError = @Sendable (
+    package typealias OnError = @Sendable (
         _ context: OpenFeatureHookContext,
         _ error: any Error,
         _ hints: OpenFeatureHookHints
     ) -> Void
 
-    typealias AfterEvaluation = @Sendable (
+    package typealias AfterEvaluation = @Sendable (
         _ context: OpenFeatureHookContext,
         _ evaluation: AnyOpenFeatureEvaluation,
         _ hints: OpenFeatureHookHints
     ) -> Void
 
-    var beforeEvaluation: BeforeEvaluation?
-    var afterSuccessfulEvaluation: AfterSuccessfulEvaluation?
-    var onError: OnError?
-    var afterEvaluation: AfterEvaluation?
+    package var beforeEvaluation: BeforeEvaluation?
+    package var afterSuccessfulEvaluation: AfterSuccessfulEvaluation?
+    package var onError: OnError?
+    package var afterEvaluation: AfterEvaluation?
 
-    func beforeEvaluation(
+    package init(
+        beforeEvaluation: BeforeEvaluation? = nil,
+        afterSuccessfulEvaluation: AfterSuccessfulEvaluation? = nil,
+        onError: OnError? = nil,
+        afterEvaluation: AfterEvaluation? = nil
+    ) {
+        self.beforeEvaluation = beforeEvaluation
+        self.afterSuccessfulEvaluation = afterSuccessfulEvaluation
+        self.onError = onError
+        self.afterEvaluation = afterEvaluation
+    }
+
+    package func beforeEvaluation(
         context: inout OpenFeatureHookContext,
         hints: [String: OpenFeatureFieldValue]
     ) throws {
         try beforeEvaluation?(&context, hints)
     }
 
-    func afterSuccessfulEvaluation(
+    package func afterSuccessfulEvaluation(
         context: OpenFeatureHookContext,
         evaluation: OpenFeatureEvaluation<some OpenFeatureValue>,
         hints: [String: OpenFeatureFieldValue]
@@ -57,11 +69,11 @@ struct OpenFeatureClosureHook: OpenFeatureHook {
         try afterSuccessfulEvaluation?(context, evaluation.eraseToAnyEvaluation(), hints)
     }
 
-    func onError(context: OpenFeatureHookContext, error: any Error, hints: OpenFeatureHookHints) {
+    package func onError(context: OpenFeatureHookContext, error: any Error, hints: OpenFeatureHookHints) {
         onError?(context, error, hints)
     }
 
-    func afterEvaluation(
+    package func afterEvaluation(
         context: OpenFeatureHookContext,
         evaluation: OpenFeatureEvaluation<some OpenFeatureValue>,
         hints: OpenFeatureHookHints
@@ -70,13 +82,13 @@ struct OpenFeatureClosureHook: OpenFeatureHook {
     }
 }
 
-struct AnyOpenFeatureEvaluation {
-    let flag: String
-    let value: any OpenFeatureValue
-    let error: OpenFeatureResolutionError?
-    let reason: OpenFeatureResolutionReason?
-    let variant: String?
-    let flagMetadata: [String: OpenFeatureFlagMetadataValue]
+package struct AnyOpenFeatureEvaluation {
+    package let flag: String
+    package let value: any OpenFeatureValue
+    package let error: OpenFeatureResolutionError?
+    package let reason: OpenFeatureResolutionReason?
+    package let variant: String?
+    package let flagMetadata: [String: OpenFeatureFlagMetadataValue]
 
     fileprivate init(_ evaluation: OpenFeatureEvaluation<some OpenFeatureValue>) {
         self.flag = evaluation.flag
@@ -88,7 +100,7 @@ struct AnyOpenFeatureEvaluation {
     }
 }
 
-extension OpenFeatureEvaluation {
+private extension OpenFeatureEvaluation {
     func eraseToAnyEvaluation() -> AnyOpenFeatureEvaluation {
         AnyOpenFeatureEvaluation(self)
     }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
@@ -14,20 +14,20 @@
 import OpenFeature
 import ServiceLifecycle
 
-actor OpenFeatureRecordingProvider: OpenFeatureProvider {
-    let metadata = OpenFeatureProviderMetadata(name: "recording")
-    let hooks: [any OpenFeatureHook]
-    var boolResolutionRequests = [ResolutionRequest<Bool>]()
+package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
+    package let metadata = OpenFeatureProviderMetadata(name: "recording")
+    package let hooks: [any OpenFeatureHook]
+    package var boolResolutionRequests = [ResolutionRequest<Bool>]()
 
-    init(hooks: [any OpenFeatureHook] = []) {
+    package init(hooks: [any OpenFeatureHook] = []) {
         self.hooks = hooks
     }
 
-    func run() async throws {
+    package func run() async throws {
         try await gracefulShutdown()
     }
 
-    func resolution(
+    package func resolution(
         of flag: String,
         defaultValue: Bool,
         context: OpenFeatureEvaluationContext?
@@ -37,9 +37,9 @@ actor OpenFeatureRecordingProvider: OpenFeatureProvider {
         return OpenFeatureResolution(value: defaultValue)
     }
 
-    struct ResolutionRequest<Value: Sendable> {
-        let flag: String
-        let defaultValue: Value
-        let context: OpenFeatureEvaluationContext?
+    package struct ResolutionRequest<Value: Sendable> {
+        package let flag: String
+        package let defaultValue: Value
+        package let context: OpenFeatureEvaluationContext?
     }
 }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
@@ -14,22 +14,22 @@
 import OpenFeature
 import ServiceLifecycle
 
-struct OpenFeatureStaticProvider: OpenFeatureProvider {
-    let metadata = OpenFeatureProviderMetadata(name: "static")
-    let hooks: [any OpenFeatureHook]
+package struct OpenFeatureStaticProvider: OpenFeatureProvider {
+    package let metadata = OpenFeatureProviderMetadata(name: "static")
+    package let hooks: [any OpenFeatureHook]
 
     private let boolResolution: OpenFeatureResolution<Bool>
 
-    init(boolResolution: OpenFeatureResolution<Bool>, hooks: [any OpenFeatureHook] = []) {
+    package init(boolResolution: OpenFeatureResolution<Bool>, hooks: [any OpenFeatureHook] = []) {
         self.boolResolution = boolResolution
         self.hooks = hooks
     }
 
-    func run() async throws {
+    package func run() async throws {
         try await gracefulShutdown()
     }
 
-    func resolution(
+    package func resolution(
         of flag: String,
         defaultValue: Bool,
         context: OpenFeatureEvaluationContext?

--- a/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
@@ -50,8 +50,16 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
             let span = InstrumentationSystem.tracer.activeSpan(identifiedBy: serviceContext)
         else { return }
 
+        let errorType: String
+        if let error = error as? OpenFeatureResolutionError {
+            errorType = error.code.rawValue.lowercased()
+        } else {
+            errorType = "general"
+        }
+
         var eventAttributes: SpanAttributes = [
-            "feature_flag.key": "\(context.flag)"
+            "feature_flag.key": "\(context.flag)",
+            "error.type": "\(errorType)"
         ]
 
         if let providerMetadata = context.providerMetadata {

--- a/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OpenFeature open source project
+//
+// Copyright (c) 2024 the Swift OpenFeature project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OpenFeature
+import Tracing
+
+public struct OpenFeatureTracingHook: OpenFeatureHook {
+    private let setSpanStatusOnError: Bool
+
+    public init(setSpanStatusOnError: Bool = false) {
+        self.setSpanStatusOnError = setSpanStatusOnError
+    }
+
+    public func afterSuccessfulEvaluation(
+        context: OpenFeatureHookContext,
+        evaluation: OpenFeatureEvaluation<some OpenFeatureValue>,
+        hints: OpenFeatureHookHints
+    ) throws {
+        guard let serviceContext = ServiceContext.current,
+            let span = InstrumentationSystem.tracer.activeSpan(identifiedBy: serviceContext)
+        else { return }
+
+        var eventAttributes: SpanAttributes = [
+            "feature_flag.key": "\(context.flag)"
+        ]
+
+        if let providerMetadata = context.providerMetadata {
+            eventAttributes["feature_flag.provider_name"] = providerMetadata.name
+        }
+
+        if let variant = evaluation.variant {
+            eventAttributes["feature_flag.variant"] = variant
+        }
+
+        span.addEvent(SpanEvent(name: "feature_flag", attributes: eventAttributes))
+    }
+
+    public func onError(context: OpenFeatureHookContext, error: any Error, hints: OpenFeatureHookHints) {
+        guard let serviceContext = ServiceContext.current,
+            let span = InstrumentationSystem.tracer.activeSpan(identifiedBy: serviceContext)
+        else { return }
+
+        var eventAttributes: SpanAttributes = [
+            "feature_flag.key": "\(context.flag)"
+        ]
+
+        if let providerMetadata = context.providerMetadata {
+            eventAttributes["feature_flag.provider_name"] = providerMetadata.name
+        }
+
+        span.recordError(error, attributes: eventAttributes)
+
+        if setSpanStatusOnError {
+            let message = #"Error evaluating flag "\#(context.flag)" of type "\#(type(of: context.defaultValue))"."#
+            span.setStatus(SpanStatus(code: .error, message: message))
+        }
+    }
+}

--- a/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
@@ -51,6 +51,10 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
             eventAttributes["feature_flag.context.id"] = targetingKey
         }
 
+        if let reason = evaluation.reason {
+            eventAttributes["feature_flag.evaluation.reason"] = reason.rawValue.lowercased()
+        }
+
         span.addEvent(SpanEvent(name: "feature_flag", attributes: eventAttributes))
     }
 

--- a/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
@@ -60,10 +60,13 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
         else { return }
 
         let errorType: String
+        let evaluationErrorMessage: String?
         if let error = error as? OpenFeatureResolutionError {
             errorType = error.code.rawValue.lowercased()
+            evaluationErrorMessage = error.message
         } else {
             errorType = "general"
+            evaluationErrorMessage = nil
         }
 
         var eventAttributes: SpanAttributes = [
@@ -78,6 +81,11 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
         if recordTargetingKey, let targetingKey = context.evaluationContext.targetingKey {
             eventAttributes["feature_flag.context.id"] = targetingKey
         }
+
+        if let evaluationErrorMessage {
+            eventAttributes["feature_flag.evaluation.error.message"] = evaluationErrorMessage
+        }
+
         span.recordError(error, attributes: eventAttributes)
 
         if setSpanStatusOnError {

--- a/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeatureTracing/OpenFeatureTracingHook.swift
@@ -71,7 +71,7 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
 
         var eventAttributes: SpanAttributes = [
             "feature_flag.key": "\(context.flag)",
-            "error.type": "\(errorType)"
+            "error.type": "\(errorType)",
         ]
 
         if let providerMetadata = context.providerMetadata {

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import OpenFeature
+import OpenFeatureTestSupport
 import Synchronization
 import Testing
 

--- a/Tests/OpenFeatureTests/OpenFeatureSystemTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureSystemTests.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import OpenFeature
+import OpenFeatureTestSupport
 import ServiceLifecycle
 import Testing
 

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -91,6 +91,7 @@ final class OpenFeatureTracingHookTests {
             attributes == [
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
+                "error.type": "flag_not_found",
             ]
         )
         #expect(span.status == nil)
@@ -110,6 +111,7 @@ final class OpenFeatureTracingHookTests {
             attributes == [
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
+                "error.type": "flag_not_found",
             ]
         )
         #expect(span.status == SpanStatus(code: .error, message: #"Error evaluating flag "flag" of type "Bool"."#))

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -128,6 +128,7 @@ final class OpenFeatureTracingHookTests {
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
                 "error.type": "flag_not_found",
+                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#
             ]
         )
         #expect(span.status == nil)
@@ -148,6 +149,7 @@ final class OpenFeatureTracingHookTests {
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
                 "error.type": "flag_not_found",
+                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#
             ]
         )
         #expect(span.status == SpanStatus(code: .error, message: #"Error evaluating flag "flag" of type "Bool"."#))

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -128,7 +128,7 @@ final class OpenFeatureTracingHookTests {
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
                 "error.type": "flag_not_found",
-                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#
+                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#,
             ]
         )
         #expect(span.status == nil)
@@ -149,7 +149,7 @@ final class OpenFeatureTracingHookTests {
                 "feature_flag.key": "flag",
                 "feature_flag.provider_name": "static",
                 "error.type": "flag_not_found",
-                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#
+                "feature_flag.evaluation.error.message": #"Flag "flag" not found."#,
             ]
         )
         #expect(span.status == SpanStatus(code: .error, message: #"Error evaluating flag "flag" of type "Bool"."#))

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -66,6 +66,21 @@ final class OpenFeatureTracingHookTests {
         )
     }
 
+    @Test("Adds span event with reason")
+    func withReason() async throws {
+        let span = try await span(evaluating: OpenFeatureResolution(value: true, reason: .targetingMatch))
+        let event = try #require(span.events.first)
+
+        #expect(event.name == "feature_flag")
+        #expect(
+            event.attributes == [
+                "feature_flag.key": "flag",
+                "feature_flag.provider_name": "static",
+                "feature_flag.evaluation.reason": "targeting_match",
+            ]
+        )
+    }
+
     @Test("Does not add targeting key by default")
     func withoutTargetingKeyByDefault() async throws {
         let span = try await span(

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -191,7 +191,7 @@ final class OpenFeatureTracingHookTests {
                 "feature_flag.provider_name": "static",
                 "error.type": "flag_not_found",
                 "feature_flag.evaluation.error.message": #"Flag "flag" not found."#,
-                "feature_flag.context.id": "public"
+                "feature_flag.context.id": "public",
             ]
         )
         #expect(span.status == nil)

--- a/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTracingTests/OpenFeatureTracingHookTests.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OpenFeature open source project
+//
+// Copyright (c) 2024 the Swift OpenFeature project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OpenFeature
+import OpenFeatureTestSupport
+import OpenFeatureTracing
+import Testing
+import Tracing
+
+@testable import Instrumentation
+
+@Suite("OpenFeatureTracingHook", .serialized)
+final class OpenFeatureTracingHookTests {
+    deinit {
+        InstrumentationSystem.bootstrapInternal(nil)
+    }
+
+    @Test("No-op without active span")
+    func noOpWithoutActiveSpan() async throws {
+        let hook = OpenFeatureTracingHook()
+        let provider = OpenFeatureStaticProvider(boolResolution: OpenFeatureResolution(value: true))
+        let client = OpenFeatureClient(provider: { provider }, hooks: [hook])
+
+        let evaluation = await client.evaluation(of: "flag", defaultingTo: true)
+
+        #expect(evaluation.value == true)
+        #expect(evaluation.error == nil)
+    }
+
+    @Test("Adds span event without variant")
+    func withoutVariant() async throws {
+        let span = try await span(evaluating: OpenFeatureResolution(value: true))
+        let event = try #require(span.events.first)
+
+        #expect(event.name == "feature_flag")
+        #expect(
+            event.attributes == [
+                "feature_flag.key": "flag",
+                "feature_flag.provider_name": "static",
+            ]
+        )
+    }
+
+    @Test("Adds span event with variant")
+    func withVariant() async throws {
+        let span = try await span(evaluating: OpenFeatureResolution(value: true, variant: "a"))
+        let event = try #require(span.events.first)
+
+        #expect(event.name == "feature_flag")
+        #expect(
+            event.attributes == [
+                "feature_flag.key": "flag",
+                "feature_flag.variant": "a",
+                "feature_flag.provider_name": "static",
+            ]
+        )
+    }
+
+    @Test("No-op error without active span")
+    func noOpErrorWithoutActiveSpan() async throws {
+        let hook = OpenFeatureTracingHook()
+        let resolutionError = OpenFeatureResolutionError(code: .flagNotFound, message: #"Flag "flag" not found."#)
+        let resolution = OpenFeatureResolution(value: true, error: resolutionError)
+        let provider = OpenFeatureStaticProvider(boolResolution: resolution)
+        let client = OpenFeatureClient(provider: { provider }, hooks: [hook])
+
+        let evaluation = await client.evaluation(of: "flag", defaultingTo: true)
+
+        #expect(evaluation.value == true)
+        #expect(evaluation.error == resolutionError)
+    }
+
+    @Test("Records error")
+    func recordsError() async throws {
+        let resolutionError = OpenFeatureResolutionError(code: .flagNotFound, message: #"Flag "flag" not found."#)
+        let span = try await span(evaluating: OpenFeatureResolution(value: true, error: resolutionError))
+        let (error, attributes) = try #require(span.errors.first)
+
+        #expect(error as? OpenFeatureResolutionError == resolutionError)
+        #expect(
+            attributes == [
+                "feature_flag.key": "flag",
+                "feature_flag.provider_name": "static",
+            ]
+        )
+        #expect(span.status == nil)
+    }
+
+    @Test("Sets span status on error")
+    func setsSpanStatusOnError() async throws {
+        let resolutionError = OpenFeatureResolutionError(code: .flagNotFound, message: #"Flag "flag" not found."#)
+        let span = try await span(
+            evaluating: OpenFeatureResolution(value: true, error: resolutionError),
+            hook: OpenFeatureTracingHook(setSpanStatusOnError: true)
+        )
+        let (error, attributes) = try #require(span.errors.first)
+
+        #expect(error as? OpenFeatureResolutionError == resolutionError)
+        #expect(
+            attributes == [
+                "feature_flag.key": "flag",
+                "feature_flag.provider_name": "static",
+            ]
+        )
+        #expect(span.status == SpanStatus(code: .error, message: #"Error evaluating flag "flag" of type "Bool"."#))
+    }
+
+    private func span(
+        evaluating resolution: OpenFeatureResolution<Bool>,
+        hook: OpenFeatureTracingHook = OpenFeatureTracingHook()
+    ) async throws -> SingleSpanTracer.Span {
+        let tracer = SingleSpanTracer()
+        InstrumentationSystem.bootstrapInternal(tracer)
+        let provider = OpenFeatureStaticProvider(boolResolution: resolution, hooks: [hook])
+        let client = OpenFeatureClient(provider: { provider })
+
+        await withSpan("test") { _ in
+            _ = await client.value(for: "flag", defaultingTo: false)
+        }
+
+        return try #require(tracer.span)
+    }
+}

--- a/Tests/OpenFeatureTracingTests/SingleSpanTracer.swift
+++ b/Tests/OpenFeatureTracingTests/SingleSpanTracer.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OpenFeature open source project
+//
+// Copyright (c) 2024 the Swift OpenFeature project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ServiceContextModule
+import Synchronization
+import Tracing
+
+final class SingleSpanTracer: Tracer {
+    var span: Span? { _span.withLock(\.self) }
+    private let _span = Mutex<Span?>(nil)
+
+    func inject<Carrier, Inject>(
+        _ context: ServiceContext,
+        into carrier: inout Carrier,
+        using injector: Inject
+    ) where Carrier == Inject.Carrier, Inject: Injector {}
+
+    func extract<Carrier, Extract>(
+        _ carrier: Carrier,
+        into context: inout ServiceContext,
+        using extractor: Extract
+    ) where Carrier == Extract.Carrier, Extract: Extractor {}
+
+    func forceFlush() {}
+
+    func startSpan<Instant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> Span where Instant: TracerInstant {
+        let span = Span(
+            context: context(),
+            operationName: operationName,
+            attributes: [:],
+            isRecording: true
+        )
+        self._span.withLock { $0 = span }
+        return span
+    }
+
+    func activeSpan(identifiedBy context: ServiceContext) -> Span? {
+        _span.withLock(\.self)
+    }
+
+    final class Span: Tracing.Span {
+        let context: ServiceContext
+        let isRecording: Bool
+
+        var operationName: String {
+            get {
+                _operationName.withLock(\.self)
+            }
+            set {
+                _operationName.withLock { $0 = newValue }
+            }
+        }
+        private let _operationName: Mutex<String>
+
+        var attributes: SpanAttributes {
+            get {
+                _attributes.withLock(\.self)
+            }
+            set {
+                _attributes.withLock { $0 = newValue }
+            }
+        }
+        private let _attributes: Mutex<SpanAttributes>
+
+        var events: [SpanEvent] {
+            get {
+                _events.withLock(\.self)
+            }
+            set {
+                _events.withLock { $0 = newValue }
+            }
+        }
+        private let _events = Mutex<[SpanEvent]>([])
+
+        var errors: [(any Error, SpanAttributes)] {
+            get {
+                _errors.withLock(\.self)
+            }
+            set {
+                _errors.withLock { $0 = newValue }
+            }
+        }
+        private let _errors = Mutex<[(any Error, SpanAttributes)]>([])
+
+        var status: SpanStatus? {
+            get {
+                _status.withLock(\.self)
+            }
+            set {
+                _status.withLock { $0 = newValue }
+            }
+        }
+        private let _status = Mutex<SpanStatus?>(nil)
+
+        init(context: ServiceContext, operationName: String, attributes: SpanAttributes, isRecording: Bool) {
+            self.context = context
+            self._operationName = Mutex(operationName)
+            self._attributes = Mutex(attributes)
+            self.isRecording = isRecording
+        }
+
+        func setStatus(_ status: SpanStatus) {
+            _status.withLock { $0 = status }
+        }
+
+        func addEvent(_ event: SpanEvent) {
+            _events.withLock { $0.append(event) }
+        }
+
+        func recordError(
+            _ error: any Error,
+            attributes: SpanAttributes,
+            at instant: @autoclosure () -> some TracerInstant
+        ) {
+            _errors.withLock { $0.append((error, attributes)) }
+        }
+
+        func addLink(_ link: SpanLink) {}
+
+        func end(at instant: @autoclosure () -> some TracerInstant) {}
+    }
+}


### PR DESCRIPTION
Builds on https://github.com/apple/swift-distributed-tracing/pull/160 to add a tracing hook which adds and event/error after feature flag evaluation to the active span (e.g. an HTTP server span).

It also optionally sets the active span's status in case an error occurs.

All span attributes are based on the experimental OTel semantic conventions for feature flags: https://github.com/apple/swift-distributed-tracing/pull/160