### PR TITLE
Add Int and Double evaluation APIs to client

### DIFF
--- a/Sources/OpenFeature/Client/OpenFeatureClient.swift
+++ b/Sources/OpenFeature/Client/OpenFeatureClient.swift
@@ -50,6 +50,22 @@ public actor OpenFeatureClient: Sendable {
         ).value
     }
 
+    public func value(
+        for flag: String,
+        defaultingTo defaultValue: Int,
+        context: OpenFeatureEvaluationContext? = nil,
+        hooks: [any OpenFeatureHook] = [],
+        hookHints: [String: OpenFeatureFieldValue] = [:]
+    ) async -> Int {
+        await evaluation(
+            of: flag,
+            defaultingTo: defaultValue,
+            context: context,
+            hooks: hooks,
+            hookHints: hookHints
+        ).value
+    }
+
     public func evaluation(
         of flag: String,
         defaultingTo defaultValue: Bool,
@@ -76,6 +92,25 @@ public actor OpenFeatureClient: Sendable {
         hooks: [any OpenFeatureHook] = [],
         hookHints: [String: OpenFeatureFieldValue] = [:]
     ) async -> OpenFeatureEvaluation<String> {
+        await evaluation(
+            of: flag,
+            defaultingTo: defaultValue,
+            context: context,
+            hooks: hooks,
+            hookHints: hookHints,
+            performResolution: { provider, flag, defaultValue, context in
+                await provider.resolution(of: flag, defaultValue: defaultValue, context: context)
+            }
+        )
+    }
+
+    public func evaluation(
+        of flag: String,
+        defaultingTo defaultValue: Int,
+        context: OpenFeatureEvaluationContext? = nil,
+        hooks: [any OpenFeatureHook] = [],
+        hookHints: [String: OpenFeatureFieldValue] = [:]
+    ) async -> OpenFeatureEvaluation<Int> {
         await evaluation(
             of: flag,
             defaultingTo: defaultValue,

--- a/Sources/OpenFeature/Client/OpenFeatureClient.swift
+++ b/Sources/OpenFeature/Client/OpenFeatureClient.swift
@@ -66,6 +66,22 @@ public actor OpenFeatureClient: Sendable {
         ).value
     }
 
+    public func value(
+        for flag: String,
+        defaultingTo defaultValue: Double,
+        context: OpenFeatureEvaluationContext? = nil,
+        hooks: [any OpenFeatureHook] = [],
+        hookHints: [String: OpenFeatureFieldValue] = [:]
+    ) async -> Double {
+        await evaluation(
+            of: flag,
+            defaultingTo: defaultValue,
+            context: context,
+            hooks: hooks,
+            hookHints: hookHints
+        ).value
+    }
+
     public func evaluation(
         of flag: String,
         defaultingTo defaultValue: Bool,
@@ -111,6 +127,25 @@ public actor OpenFeatureClient: Sendable {
         hooks: [any OpenFeatureHook] = [],
         hookHints: [String: OpenFeatureFieldValue] = [:]
     ) async -> OpenFeatureEvaluation<Int> {
+        await evaluation(
+            of: flag,
+            defaultingTo: defaultValue,
+            context: context,
+            hooks: hooks,
+            hookHints: hookHints,
+            performResolution: { provider, flag, defaultValue, context in
+                await provider.resolution(of: flag, defaultValue: defaultValue, context: context)
+            }
+        )
+    }
+
+    public func evaluation(
+        of flag: String,
+        defaultingTo defaultValue: Double,
+        context: OpenFeatureEvaluationContext? = nil,
+        hooks: [any OpenFeatureHook] = [],
+        hookHints: [String: OpenFeatureFieldValue] = [:]
+    ) async -> OpenFeatureEvaluation<Double> {
         await evaluation(
             of: flag,
             defaultingTo: defaultValue,

--- a/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
@@ -28,6 +28,12 @@ public protocol OpenFeatureProvider: Service {
         defaultValue: String,
         context: OpenFeatureEvaluationContext?
     ) async -> OpenFeatureResolution<String>
+
+    func resolution(
+        of flag: String,
+        defaultValue: Int,
+        context: OpenFeatureEvaluationContext?
+    ) async -> OpenFeatureResolution<Int>
 }
 
 extension OpenFeatureProvider {

--- a/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
@@ -34,6 +34,12 @@ public protocol OpenFeatureProvider: Service {
         defaultValue: Int,
         context: OpenFeatureEvaluationContext?
     ) async -> OpenFeatureResolution<Int>
+
+    func resolution(
+        of flag: String,
+        defaultValue: Double,
+        context: OpenFeatureEvaluationContext?
+    ) async -> OpenFeatureResolution<Double>
 }
 
 extension OpenFeatureProvider {

--- a/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
@@ -21,6 +21,7 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
     package var boolResolutionRequests = [ResolutionRequest<Bool>]()
     package var stringResolutionRequests = [ResolutionRequest<String>]()
     package var intResolutionRequests = [ResolutionRequest<Int>]()
+    package var doubleResolutionRequests = [ResolutionRequest<Double>]()
 
     package init(hooks: [any OpenFeatureHook] = []) {
         self.hooks = hooks
@@ -69,6 +70,20 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
             context: context
         )
         intResolutionRequests.append(request)
+        return OpenFeatureResolution(value: defaultValue)
+    }
+
+    package func resolution(
+        of flag: String,
+        defaultValue: Double,
+        context: OpenFeatureEvaluationContext?
+    ) async -> OpenFeatureResolution<Double> {
+        let request = ResolutionRequest(
+            flag: flag,
+            defaultValue: defaultValue,
+            context: context
+        )
+        doubleResolutionRequests.append(request)
         return OpenFeatureResolution(value: defaultValue)
     }
 

--- a/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
@@ -20,6 +20,7 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
 
     package var boolResolutionRequests = [ResolutionRequest<Bool>]()
     package var stringResolutionRequests = [ResolutionRequest<String>]()
+    package var intResolutionRequests = [ResolutionRequest<Int>]()
 
     package init(hooks: [any OpenFeatureHook] = []) {
         self.hooks = hooks
@@ -54,6 +55,20 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
             context: context
         )
         stringResolutionRequests.append(request)
+        return OpenFeatureResolution(value: defaultValue)
+    }
+
+    package func resolution(
+        of flag: String,
+        defaultValue: Int,
+        context: OpenFeatureEvaluationContext?
+    ) async -> OpenFeatureResolution<Int> {
+        let request = ResolutionRequest(
+            flag: flag,
+            defaultValue: defaultValue,
+            context: context
+        )
+        intResolutionRequests.append(request)
         return OpenFeatureResolution(value: defaultValue)
     }
 

--- a/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
@@ -21,16 +21,19 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
     private let boolResolution: OpenFeatureResolution<Bool>?
     private let stringResolution: OpenFeatureResolution<String>?
     private let intResolution: OpenFeatureResolution<Int>?
+    private let doubleResolution: OpenFeatureResolution<Double>?
 
     package init(
         boolResolution: OpenFeatureResolution<Bool>? = nil,
         stringResolution: OpenFeatureResolution<String>? = nil,
         intResolution: OpenFeatureResolution<Int>? = nil,
+        doubleResolution: OpenFeatureResolution<Double>? = nil,
         hooks: [any OpenFeatureHook] = []
     ) {
         self.boolResolution = boolResolution
         self.stringResolution = stringResolution
         self.intResolution = intResolution
+        self.doubleResolution = doubleResolution
         self.hooks = hooks
     }
 
@@ -60,5 +63,13 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
         context: OpenFeature.OpenFeatureEvaluationContext?
     ) async -> OpenFeature.OpenFeatureResolution<Int> {
         intResolution!
+    }
+
+    package func resolution(
+        of flag: String,
+        defaultValue: Double,
+        context: OpenFeature.OpenFeatureEvaluationContext?
+    ) async -> OpenFeature.OpenFeatureResolution<Double> {
+        doubleResolution!
     }
 }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
@@ -20,14 +20,17 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
 
     private let boolResolution: OpenFeatureResolution<Bool>?
     private let stringResolution: OpenFeatureResolution<String>?
+    private let intResolution: OpenFeatureResolution<Int>?
 
     package init(
         boolResolution: OpenFeatureResolution<Bool>? = nil,
         stringResolution: OpenFeatureResolution<String>? = nil,
+        intResolution: OpenFeatureResolution<Int>? = nil,
         hooks: [any OpenFeatureHook] = []
     ) {
         self.boolResolution = boolResolution
         self.stringResolution = stringResolution
+        self.intResolution = intResolution
         self.hooks = hooks
     }
 
@@ -49,5 +52,13 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
         context: OpenFeature.OpenFeatureEvaluationContext?
     ) async -> OpenFeature.OpenFeatureResolution<String> {
         stringResolution!
+    }
+
+    package func resolution(
+        of flag: String,
+        defaultValue: Int,
+        context: OpenFeature.OpenFeatureEvaluationContext?
+    ) async -> OpenFeature.OpenFeatureResolution<Int> {
+        intResolution!
     }
 }

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -87,6 +87,29 @@ struct OpenFeatureClientTests {
         }
     }
 
+    @Suite("Double")
+    struct DoubleTests {
+        @Test("value", arguments: [-10.0, 123.45])
+        func value(_ defaultValue: Double) async {
+            let provider = OpenFeatureDefaultValueProvider()
+            let client = OpenFeatureClient(provider: { provider })
+
+            let value = await client.value(for: "flag", defaultingTo: defaultValue)
+
+            #expect(value == defaultValue)
+        }
+
+        @Test("evaluation", arguments: [-10.0, 123.45])
+        func evaluation(_ defaultValue: Double) async {
+            let provider = OpenFeatureDefaultValueProvider()
+            let client = OpenFeatureClient(provider: { provider })
+
+            let evaluation = await client.evaluation(of: "flag", defaultingTo: defaultValue)
+
+            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: defaultValue))
+        }
+    }
+
     @Suite("Evaluation Context Merging")
     struct EvaluationContextMergingTests {
         @Test("Starts with global")

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -64,6 +64,29 @@ struct OpenFeatureClientTests {
         }
     }
 
+    @Suite("Int")
+    struct IntTests {
+        @Test("value", arguments: [0, 42])
+        func value(_ defaultValue: Int) async {
+            let provider = OpenFeatureDefaultValueProvider()
+            let client = OpenFeatureClient(provider: { provider })
+
+            let value = await client.value(for: "flag", defaultingTo: defaultValue)
+
+            #expect(value == defaultValue)
+        }
+
+        @Test("evaluation", arguments: [0, 42])
+        func evaluation(_ defaultValue: Int) async {
+            let provider = OpenFeatureDefaultValueProvider()
+            let client = OpenFeatureClient(provider: { provider })
+
+            let evaluation = await client.evaluation(of: "flag", defaultingTo: defaultValue)
+
+            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: defaultValue))
+        }
+    }
+
     @Suite("Evaluation Context Merging")
     struct EvaluationContextMergingTests {
         @Test("Starts with global")

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -66,47 +66,47 @@ struct OpenFeatureClientTests {
 
     @Suite("Int")
     struct IntTests {
-        @Test("value", arguments: [0, 42])
-        func value(_ defaultValue: Int) async {
-            let provider = OpenFeatureDefaultValueProvider()
+        @Test("value", arguments: [-42, 0, 42])
+        func value(_ value: Int) async {
+            let provider = OpenFeatureStaticProvider(intResolution: OpenFeatureResolution(value: value))
             let client = OpenFeatureClient(provider: { provider })
 
-            let value = await client.value(for: "flag", defaultingTo: defaultValue)
+            let resolvedValue = await client.value(for: "flag", defaultingTo: 1000)
 
-            #expect(value == defaultValue)
+            #expect(resolvedValue == value)
         }
 
-        @Test("evaluation", arguments: [0, 42])
-        func evaluation(_ defaultValue: Int) async {
-            let provider = OpenFeatureDefaultValueProvider()
+        @Test("evaluation", arguments: [-42, 0, 42])
+        func evaluation(_ value: Int) async {
+            let provider = OpenFeatureStaticProvider(intResolution: OpenFeatureResolution(value: value))
             let client = OpenFeatureClient(provider: { provider })
 
-            let evaluation = await client.evaluation(of: "flag", defaultingTo: defaultValue)
+            let evaluation = await client.evaluation(of: "flag", defaultingTo: 1000)
 
-            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: defaultValue))
+            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: value))
         }
     }
 
     @Suite("Double")
     struct DoubleTests {
-        @Test("value", arguments: [-10.0, 123.45])
-        func value(_ defaultValue: Double) async {
-            let provider = OpenFeatureDefaultValueProvider()
+        @Test("value", arguments: [-4.2, 0.0, 4.2])
+        func value(_ value: Double) async {
+            let provider = OpenFeatureStaticProvider(doubleResolution: OpenFeatureResolution(value: value))
             let client = OpenFeatureClient(provider: { provider })
 
-            let value = await client.value(for: "flag", defaultingTo: defaultValue)
+            let resolvedValue = await client.value(for: "flag", defaultingTo: 1000.0)
 
-            #expect(value == defaultValue)
+            #expect(resolvedValue == value)
         }
 
-        @Test("evaluation", arguments: [-10.0, 123.45])
-        func evaluation(_ defaultValue: Double) async {
-            let provider = OpenFeatureDefaultValueProvider()
+        @Test("evaluation", arguments: [-4.2, 0.0, 4.2])
+        func evaluation(_ value: Double) async {
+            let provider = OpenFeatureStaticProvider(doubleResolution: OpenFeatureResolution(value: value))
             let client = OpenFeatureClient(provider: { provider })
 
-            let evaluation = await client.evaluation(of: "flag", defaultingTo: defaultValue)
+            let evaluation = await client.evaluation(of: "flag", defaultingTo: 1000.0)
 
-            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: defaultValue))
+            #expect(evaluation == OpenFeatureEvaluation(flag: "flag", value: value))
         }
     }
 

--- a/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
@@ -89,6 +89,13 @@ struct OpenFeatureNoOpProviderTests {
 
             #expect(resolution == .fromNoOpProvider(value: value))
         }
+
+        @Test("Double uses default", arguments: [-10.0, 123.45])
+        func string(_ value: Double) async {
+            let resolution = await provider.resolution(of: "flag", defaultValue: value, context: nil)
+
+            #expect(resolution == .fromNoOpProvider(value: value))
+        }
     }
 }
 

--- a/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
@@ -82,6 +82,13 @@ struct OpenFeatureNoOpProviderTests {
 
             #expect(resolution == .fromNoOpProvider(value: value))
         }
+
+        @Test("Int uses default", arguments: [0, 42])
+        func string(_ value: Int) async {
+            let resolution = await provider.resolution(of: "flag", defaultValue: value, context: nil)
+
+            #expect(resolution == .fromNoOpProvider(value: value))
+        }
     }
 }
 

--- a/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
@@ -83,15 +83,15 @@ struct OpenFeatureNoOpProviderTests {
             #expect(resolution == .fromNoOpProvider(value: value))
         }
 
-        @Test("Int uses default", arguments: [0, 42])
-        func string(_ value: Int) async {
+        @Test("Int uses default", arguments: [-42, 0, 42])
+        func int(_ value: Int) async {
             let resolution = await provider.resolution(of: "flag", defaultValue: value, context: nil)
 
             #expect(resolution == .fromNoOpProvider(value: value))
         }
 
-        @Test("Double uses default", arguments: [-10.0, 123.45])
-        func string(_ value: Double) async {
+        @Test("Double uses default", arguments: [-4.2, 0.0, 4.2])
+        func double(_ value: Double) async {
             let resolution = await provider.resolution(of: "flag", defaultValue: value, context: nil)
 
             #expect(resolution == .fromNoOpProvider(value: value))


### PR DESCRIPTION
Extends `OpenFeatureProvider` and `OpenFeatureClient` with APIs for `Int` and `Double` resolution/evaluation