### PR TITLE
Add ServiceLifecycle and DistributedTracing traits

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,8 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-unit-test
   cancel-in-progress: true
 jobs:
-  unit-test:
-    name: Unit Test
+  unit-test-all-traits:
+    name: Unit Test (All Traits)
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -43,3 +43,25 @@ jobs:
           files: ./info.lcov
           fail_ci_if_error: true
           token: "${{ secrets.CODECOV_TOKEN }}"
+
+  unit-test-default-traits:
+    name: Unit Test (Default Traits)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [latest, main-snapshot]
+    steps:
+      - name: Install Swift
+        uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: ${{ matrix.toolchain }}
+        env:
+          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Resolve Swift dependencies
+        run: swift package resolve
+      - name: Run Unit Tests
+        run: swift test --parallel

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [latest]
+        toolchain: [latest, main-snapshot]
     steps:
       - name: Install Swift
         uses: vapor/swiftly-action@v0.2
@@ -27,7 +27,7 @@ jobs:
       - name: Resolve Swift dependencies
         run: swift package resolve
       - name: Run Unit Tests
-        run: swift test --parallel --enable-code-coverage
+        run: swift test --parallel --enable-code-coverage --enable-all-traits
       - name: Merge code coverage
         run: |
           llvm-cov export -format "lcov" \

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,16 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 import PackageDescription
 
 let package = Package(
     name: "swift-open-feature",
     platforms: [.macOS(.v15)],
     products: [
-        .library(name: "OpenFeature", targets: ["OpenFeature"]),
-        .library(name: "OpenFeatureTracing", targets: ["OpenFeatureTracing"]),
+        .library(name: "OpenFeature", targets: ["OpenFeature"])
+    ],
+    traits: [
+        .trait(name: "ServiceLifecycleSupport"),
+        .trait(name: "DistributedTracingSupport"),
+        .default(enabledTraits: []),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
@@ -17,7 +21,16 @@ let package = Package(
         .target(
             name: "OpenFeature",
             dependencies: [
-                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle")
+                .product(
+                    name: "ServiceLifecycle",
+                    package: "swift-service-lifecycle",
+                    condition: .when(traits: ["ServiceLifecycleSupport"])
+                ),
+                .product(
+                    name: "Tracing",
+                    package: "swift-distributed-tracing",
+                    condition: .when(traits: ["DistributedTracingSupport"])
+                ),
             ]
         ),
         .testTarget(
@@ -27,21 +40,6 @@ let package = Package(
                 .target(name: "OpenFeatureTestSupport"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
-            ]
-        ),
-
-        .target(
-            name: "OpenFeatureTracing",
-            dependencies: [
-                .target(name: "OpenFeature"),
-                .product(name: "Tracing", package: "swift-distributed-tracing"),
-            ]
-        ),
-        .testTarget(
-            name: "OpenFeatureTracingTests",
-            dependencies: [
-                .target(name: "OpenFeatureTracing"),
-                .target(name: "OpenFeatureTestSupport"),
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
         .library(name: "OpenFeature", targets: ["OpenFeature"])
     ],
     traits: [
-        .trait(name: "ServiceLifecycleSupport"),
-        .trait(name: "DistributedTracingSupport"),
+        .trait(name: "ServiceLifecycle"),
+        .trait(name: "DistributedTracing"),
         .default(enabledTraits: []),
     ],
     dependencies: [
@@ -24,12 +24,12 @@ let package = Package(
                 .product(
                     name: "ServiceLifecycle",
                     package: "swift-service-lifecycle",
-                    condition: .when(traits: ["ServiceLifecycleSupport"])
+                    condition: .when(traits: ["ServiceLifecycle"])
                 ),
                 .product(
                     name: "Tracing",
                     package: "swift-distributed-tracing",
-                    condition: .when(traits: ["DistributedTracingSupport"])
+                    condition: .when(traits: ["DistributedTracing"])
                 ),
             ]
         ),
@@ -39,7 +39,11 @@ let package = Package(
                 .target(name: "OpenFeature"),
                 .target(name: "OpenFeatureTestSupport"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+                .product(
+                    name: "ServiceLifecycle",
+                    package: "swift-service-lifecycle",
+                    condition: .when(traits: ["ServiceLifecycle"])
+                ),
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
         .library(name: "OpenFeature", targets: ["OpenFeature"])
     ],
     traits: [
-        .trait(name: "ServiceLifecycle"),
-        .trait(name: "DistributedTracing"),
+        .trait(name: "ServiceLifecycle", description: "Adds integration with Swift Service Lifecycle."),
+        .trait(name: "DistributedTracing", description: "Adds integration with Swift Distributed Tracing."),
         .default(enabledTraits: []),
     ],
     dependencies: [

--- a/Sources/OpenFeature/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeature/OpenFeatureTracingHook.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if Tracing
+#if DistributedTracingSupport
 import Tracing
 
 public struct OpenFeatureTracingHook: OpenFeatureHook {

--- a/Sources/OpenFeature/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeature/OpenFeatureTracingHook.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DistributedTracingSupport
+#if DistributedTracing
 import Tracing
 
 public struct OpenFeatureTracingHook: OpenFeatureHook {

--- a/Sources/OpenFeature/OpenFeatureTracingHook.swift
+++ b/Sources/OpenFeature/OpenFeatureTracingHook.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import OpenFeature
+#if Tracing
 import Tracing
 
 public struct OpenFeatureTracingHook: OpenFeatureHook {
@@ -98,3 +98,4 @@ public struct OpenFeatureTracingHook: OpenFeatureHook {
         }
     }
 }
+#endif

--- a/Sources/OpenFeature/Provider/OpenFeatureNoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureNoOpProvider.swift
@@ -11,7 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if ServiceLifecycleSupport
 import ServiceLifecycle
+#endif
 
 public struct OpenFeatureNoOpProvider: OpenFeatureProvider, CustomStringConvertible {
     public let description = "OpenFeatureNoOpProvider"
@@ -21,7 +23,9 @@ public struct OpenFeatureNoOpProvider: OpenFeatureProvider, CustomStringConverti
     public init() {}
 
     public func run() async throws {
+        #if ServiceLifecycleSupport
         try await gracefulShutdown()
+        #endif
     }
 
     public func resolution<Value: OpenFeatureValue>(

--- a/Sources/OpenFeature/Provider/OpenFeatureNoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureNoOpProvider.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if ServiceLifecycleSupport
+#if ServiceLifecycle
 import ServiceLifecycle
 #endif
 
@@ -23,7 +23,7 @@ public struct OpenFeatureNoOpProvider: OpenFeatureProvider, CustomStringConverti
     public init() {}
 
     public func run() async throws {
-        #if ServiceLifecycleSupport
+        #if ServiceLifecycle
         try await gracefulShutdown()
         #endif
     }

--- a/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
@@ -11,9 +11,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if ServiceLifecycleSupport
 import ServiceLifecycle
+public typealias _OpenFeatureProviderBaseProtocol = Service
+#else
+public typealias _OpenFeatureProviderBaseProtocol = Sendable
+#endif
 
-public protocol OpenFeatureProvider: Service {
+public protocol OpenFeatureProvider: _OpenFeatureProviderBaseProtocol {
     var metadata: OpenFeatureProviderMetadata { get }
     var hooks: [any OpenFeatureHook] { get }
 
@@ -40,6 +45,8 @@ public protocol OpenFeatureProvider: Service {
         defaultValue: Double,
         context: OpenFeatureEvaluationContext?
     ) async -> OpenFeatureResolution<Double>
+
+    func run() async throws
 }
 
 extension OpenFeatureProvider {

--- a/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
+++ b/Sources/OpenFeature/Provider/OpenFeatureProvider.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if ServiceLifecycleSupport
+#if ServiceLifecycle
 import ServiceLifecycle
 public typealias _OpenFeatureProviderBaseProtocol = Service
 #else

--- a/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureClosureHook.swift
@@ -14,28 +14,32 @@
 import OpenFeature
 
 package struct OpenFeatureClosureHook: OpenFeatureHook {
-    package typealias BeforeEvaluation = @Sendable (
-        _ context: inout OpenFeatureHookContext,
-        _ hints: OpenFeatureHookHints
-    ) throws -> Void
+    package typealias BeforeEvaluation =
+        @Sendable (
+            _ context: inout OpenFeatureHookContext,
+            _ hints: OpenFeatureHookHints
+        ) throws -> Void
 
-    package typealias AfterSuccessfulEvaluation = @Sendable (
-        _ context: OpenFeatureHookContext,
-        _ evaluation: AnyOpenFeatureEvaluation,
-        _ hints: OpenFeatureHookHints
-    ) throws -> Void
+    package typealias AfterSuccessfulEvaluation =
+        @Sendable (
+            _ context: OpenFeatureHookContext,
+            _ evaluation: AnyOpenFeatureEvaluation,
+            _ hints: OpenFeatureHookHints
+        ) throws -> Void
 
-    package typealias OnError = @Sendable (
-        _ context: OpenFeatureHookContext,
-        _ error: any Error,
-        _ hints: OpenFeatureHookHints
-    ) -> Void
+    package typealias OnError =
+        @Sendable (
+            _ context: OpenFeatureHookContext,
+            _ error: any Error,
+            _ hints: OpenFeatureHookHints
+        ) -> Void
 
-    package typealias AfterEvaluation = @Sendable (
-        _ context: OpenFeatureHookContext,
-        _ evaluation: AnyOpenFeatureEvaluation,
-        _ hints: OpenFeatureHookHints
-    ) -> Void
+    package typealias AfterEvaluation =
+        @Sendable (
+            _ context: OpenFeatureHookContext,
+            _ evaluation: AnyOpenFeatureEvaluation,
+            _ hints: OpenFeatureHookHints
+        ) -> Void
 
     package var beforeEvaluation: BeforeEvaluation?
     package var afterSuccessfulEvaluation: AfterSuccessfulEvaluation?

--- a/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
@@ -13,7 +13,7 @@
 
 import OpenFeature
 
-#if ServiceLifecycleSupport
+#if ServiceLifecycle
 import ServiceLifecycle
 #endif
 
@@ -31,7 +31,7 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
     }
 
     package func run() async throws {
-        #if ServiceLifecycleSupport
+        #if ServiceLifecycle
         try await gracefulShutdown()
         #endif
     }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureRecordingProvider.swift
@@ -12,7 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 import OpenFeature
+
+#if ServiceLifecycleSupport
 import ServiceLifecycle
+#endif
 
 package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
     package let metadata = OpenFeatureProviderMetadata(name: "recording")
@@ -28,7 +31,9 @@ package actor OpenFeatureRecordingProvider: OpenFeatureProvider {
     }
 
     package func run() async throws {
+        #if ServiceLifecycleSupport
         try await gracefulShutdown()
+        #endif
     }
 
     package func resolution(

--- a/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
@@ -13,7 +13,7 @@
 
 import OpenFeature
 
-#if ServiceLifecycleSupport
+#if ServiceLifecycle
 import ServiceLifecycle
 #endif
 
@@ -41,7 +41,7 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
     }
 
     package func run() async throws {
-        #if ServiceLifecycleSupport
+        #if ServiceLifecycle
         try await gracefulShutdown()
         #endif
     }

--- a/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
+++ b/Sources/OpenFeatureTestSupport/OpenFeatureStaticProvider.swift
@@ -12,7 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 import OpenFeature
+
+#if ServiceLifecycleSupport
 import ServiceLifecycle
+#endif
 
 package struct OpenFeatureStaticProvider: OpenFeatureProvider {
     package let metadata = OpenFeatureProviderMetadata(name: "static")
@@ -38,7 +41,9 @@ package struct OpenFeatureStaticProvider: OpenFeatureProvider {
     }
 
     package func run() async throws {
+        #if ServiceLifecycleSupport
         try await gracefulShutdown()
+        #endif
     }
 
     package func resolution(

--- a/Tests/OpenFeatureTests/Helpers/OpenFeatureDefaultValueProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/OpenFeatureDefaultValueProvider.swift
@@ -12,13 +12,18 @@
 //===----------------------------------------------------------------------===//
 
 import OpenFeature
+
+#if ServiceLifecycle
 import ServiceLifecycle
+#endif
 
 struct OpenFeatureDefaultValueProvider: OpenFeatureProvider {
     let metadata = OpenFeatureProviderMetadata(name: "default-value")
 
     func run() async throws {
+        #if ServiceLifecycle
         try await gracefulShutdown()
+        #endif
     }
 
     func resolution<Value: OpenFeatureValue>(

--- a/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
@@ -13,11 +13,15 @@
 
 import Logging
 import OpenFeature
-import ServiceLifecycle
 import Testing
+
+#if ServiceLifecycleSupport
+import ServiceLifecycle
+#endif
 
 @Suite("OpenFeatureNoOpProvider")
 struct OpenFeatureNoOpProviderTests {
+    #if ServiceLifecycleSupport
     @Test("Stops on graceful shutdown")
     func gracefulShutdown() async throws {
         let provider = OpenFeatureNoOpProvider()
@@ -60,6 +64,7 @@ struct OpenFeatureNoOpProviderTests {
             try await group.waitForAll()
         }
     }
+    #endif
 
     @Suite("Resolution")
     struct ResolutionTests {

--- a/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureNoOpProviderTests.swift
@@ -15,13 +15,13 @@ import Logging
 import OpenFeature
 import Testing
 
-#if ServiceLifecycleSupport
+#if ServiceLifecycle
 import ServiceLifecycle
 #endif
 
 @Suite("OpenFeatureNoOpProvider")
 struct OpenFeatureNoOpProviderTests {
-    #if ServiceLifecycleSupport
+    #if ServiceLifecycle
     @Test("Stops on graceful shutdown")
     func gracefulShutdown() async throws {
         let provider = OpenFeatureNoOpProvider()

--- a/Tests/OpenFeatureTests/OpenFeatureSystemTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureSystemTests.swift
@@ -13,8 +13,11 @@
 
 import OpenFeature
 import OpenFeatureTestSupport
-import ServiceLifecycle
 import Testing
+
+#if ServiceLifecycle
+import ServiceLifecycle
+#endif
 
 @Suite("OpenFeatureSystem", .serialized)
 final class OpenFeatureSystemTests {

--- a/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
@@ -11,9 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if Tracing
 import OpenFeature
 import OpenFeatureTestSupport
-import OpenFeatureTracing
 import Testing
 import Tracing
 
@@ -235,3 +235,4 @@ final class OpenFeatureTracingHookTests {
         return try #require(tracer.span)
     }
 }
+#endif

--- a/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DistributedTracingSupport
+#if DistributedTracing
 import OpenFeature
 import OpenFeatureTestSupport
 import Testing

--- a/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
+++ b/Tests/OpenFeatureTests/Tracing/OpenFeatureTracingHookTests.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if Tracing
+#if DistributedTracingSupport
 import OpenFeature
 import OpenFeatureTestSupport
 import Testing

--- a/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
+++ b/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if Tracing
+#if DistributedTracingSupport
 import ServiceContextModule
 import Synchronization
 import Tracing

--- a/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
+++ b/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DistributedTracingSupport
+#if DistributedTracing
 import ServiceContextModule
 import Synchronization
 import Tracing

--- a/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
+++ b/Tests/OpenFeatureTests/Tracing/SingleSpanTracer.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if Tracing
 import ServiceContextModule
 import Synchronization
 import Tracing
@@ -138,3 +139,4 @@ final class SingleSpanTracer: Tracer {
         func end(at instant: @autoclosure () -> some TracerInstant) {}
     }
 }
+#endif


### PR DESCRIPTION
This PR bumps the minimum Swift version to 6.1 to unlock package traits. It also moves the tracing interceptor from `OpenFeatureTracing` to the main library target and puts it behind an _opt-in_ trait `DistributedTracing`. Lastly, the Swift Service Lifecycle integration is now also behind an _opt-in_ `ServiceLifecycle` trait.